### PR TITLE
Add TFMs for .NET 6, 7, 8

### DIFF
--- a/src/ServiceRegistryModules.Abstractions/ServiceRegistryModules.Abstractions.csproj
+++ b/src/ServiceRegistryModules.Abstractions/ServiceRegistryModules.Abstractions.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceRegistryModules.Abstractions/ServiceRegistryModules.Abstractions.csproj
+++ b/src/ServiceRegistryModules.Abstractions/ServiceRegistryModules.Abstractions.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 
     <PackageId>ServiceRegistryModules.Abstractions</PackageId>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>Andrew Starr</Authors>
     <Description>
       Core abstractions used in ServiceRegistryModules

--- a/src/ServiceRegistryModules.AspNetCore/ServiceRegistryModules.AspNetCore.csproj
+++ b/src/ServiceRegistryModules.AspNetCore/ServiceRegistryModules.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
 
     <PackageId>ServiceRegistryModules.AspNetCore</PackageId>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>Andrew Starr</Authors>
     <Description>
       ASP.NET extensions for ServiceRegistryModules

--- a/src/ServiceRegistryModules.AspNetCore/ServiceRegistryModules.AspNetCore.csproj
+++ b/src/ServiceRegistryModules.AspNetCore/ServiceRegistryModules.AspNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <PackageId>ServiceRegistryModules.AspNetCore</PackageId>

--- a/src/ServiceRegistryModules.AspNetCore/WebApplicationBuilderExtensions.cs
+++ b/src/ServiceRegistryModules.AspNetCore/WebApplicationBuilderExtensions.cs
@@ -18,7 +18,7 @@ public static class WebApplicationBuilderExtensions {
     /// <exception cref="RegistryConfigurationException">When there is a problem with the registry configuration</exception>
     public static void ApplyRegistries(this WebApplicationBuilder builder, params Assembly[] assemblies)
         => builder.ApplyRegistries(config => {
-            if (assemblies.Any()) {
+            if (assemblies.Length > 0) {
                 config.FromAssemblies(assemblies);
             }
         }, Assembly.GetCallingAssembly());

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryActivationException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryActivationException.cs
@@ -8,6 +8,7 @@ public class RegistryActivationException : RegistryModuleException {
     public RegistryActivationException(string message) : base(message) { }
     public RegistryActivationException(string message, Exception inner) : base(message, inner) { }
 #if !NET8_0_OR_GREATER
+    [Obsolete("This constructor is obsolete and will be removed in a future version. Use the constructor with the 'message' and 'inner' parameters instead.")]
     protected RegistryActivationException(
       System.Runtime.Serialization.SerializationInfo info,
       System.Runtime.Serialization.StreamingContext context) : base(info, context) { }

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryActivationException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryActivationException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace ServiceRegistryModules.Exceptions;
 
@@ -8,7 +7,9 @@ public class RegistryActivationException : RegistryModuleException {
     public RegistryActivationException() { }
     public RegistryActivationException(string message) : base(message) { }
     public RegistryActivationException(string message, Exception inner) : base(message, inner) { }
+#if !NET8_0_OR_GREATER
     protected RegistryActivationException(
-      SerializationInfo info,
-      StreamingContext context) : base(info, context) { }
+      System.Runtime.Serialization.SerializationInfo info,
+      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryConfigurationException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryConfigurationException.cs
@@ -8,6 +8,7 @@ public class RegistryConfigurationException : RegistryModuleException {
     public RegistryConfigurationException(string message) : base(message) { }
     public RegistryConfigurationException(string message, Exception inner) : base(message, inner) { }
 #if !NET8_0_OR_GREATER
+    [Obsolete("This constructor is obsolete and will be removed in a future version. Use the constructor with the 'message' and 'inner' parameters instead.")]
     protected RegistryConfigurationException(
       System.Runtime.Serialization.SerializationInfo info,
       System.Runtime.Serialization.StreamingContext context) : base(info, context) { }

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryConfigurationException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryConfigurationException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace ServiceRegistryModules.Exceptions;
 
@@ -8,7 +7,9 @@ public class RegistryConfigurationException : RegistryModuleException {
     public RegistryConfigurationException() { }
     public RegistryConfigurationException(string message) : base(message) { }
     public RegistryConfigurationException(string message, Exception inner) : base(message, inner) { }
+#if !NET8_0_OR_GREATER
     protected RegistryConfigurationException(
-      SerializationInfo info,
-      StreamingContext context) : base(info, context) { }
+      System.Runtime.Serialization.SerializationInfo info,
+      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryModuleException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryModuleException.cs
@@ -8,6 +8,7 @@ public abstract class RegistryModuleException : Exception {
     public RegistryModuleException(string message) : base(message) { }
     public RegistryModuleException(string message, Exception inner) : base(message, inner) { }
 #if !NET8_0_OR_GREATER
+    [Obsolete("This constructor is obsolete and will be removed in a future version. Use the constructor with the 'message' and 'inner' parameters instead.")]
     protected RegistryModuleException(
       System.Runtime.Serialization.SerializationInfo info,
       System.Runtime.Serialization.StreamingContext context) : base(info, context) { }

--- a/src/ServiceRegistryModules.Core/Exceptions/RegistryModuleException.cs
+++ b/src/ServiceRegistryModules.Core/Exceptions/RegistryModuleException.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 namespace ServiceRegistryModules.Exceptions;
 
@@ -8,7 +7,9 @@ public abstract class RegistryModuleException : Exception {
     public RegistryModuleException() { }
     public RegistryModuleException(string message) : base(message) { }
     public RegistryModuleException(string message, Exception inner) : base(message, inner) { }
+#if !NET8_0_OR_GREATER
     protected RegistryModuleException(
-      SerializationInfo info,
-      StreamingContext context) : base(info, context) { }
+      System.Runtime.Serialization.SerializationInfo info,
+      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+#endif
 }

--- a/src/ServiceRegistryModules.Core/Internal/RegistryActivator.cs
+++ b/src/ServiceRegistryModules.Core/Internal/RegistryActivator.cs
@@ -38,7 +38,7 @@ internal class RegistryActivator : IRegistryActivator {
         return IsTypePublic(type.DeclaringType);
     }
 
-    private IRegistryModule CreateRegistryInstance(ConstructorInfo ctor, RegistryOptions options) {
+    private static IRegistryModule CreateRegistryInstance(ConstructorInfo ctor, RegistryOptions options) {
         var ctorParams = ctor.GetParameters();
         var paramInstances = new object[ctorParams.Length];
 
@@ -52,7 +52,7 @@ internal class RegistryActivator : IRegistryActivator {
         return (IRegistryModule)ctor.Invoke(paramInstances);
     }
 
-    private ConstructorInfo? FindConstructorWithArgsThatSatisfy(Type registryType, IEnumerable<Type> availableArgs) {
+    private static ConstructorInfo? FindConstructorWithArgsThatSatisfy(Type registryType, IEnumerable<Type> availableArgs) {
         var availableCount = availableArgs.Count();
 
         return registryType.GetConstructors(BindingFlags.Public | BindingFlags.Instance)

--- a/src/ServiceRegistryModules.Core/Internal/RegistryConfigLoader.cs
+++ b/src/ServiceRegistryModules.Core/Internal/RegistryConfigLoader.cs
@@ -27,7 +27,7 @@ internal class RegistryConfigLoader : IRegistryConfigLoader {
                     Enum.TryParse<ConfigurationType>(propertySection.GetSection(nameof(RegistryPropertyConfig.Type)).Value, true, out var type);
 
                     if (type == ConfigurationType.Config) {
-                        var newValue = options.Configuration[value];
+                        var newValue = options.Configuration[value!];
                         if (newValue is null) {
                             if (suppressErr) {
                                 continue;

--- a/src/ServiceRegistryModules.Core/Internal/StringExtensions.cs
+++ b/src/ServiceRegistryModules.Core/Internal/StringExtensions.cs
@@ -5,13 +5,13 @@ namespace ServiceRegistryModules.Internal;
 internal static class StringExtensions {
     public static bool MatchWildcard(this string value, string check, char wildcard, StringComparison comparison = StringComparison.Ordinal) {
         var trimmedCheck = check.Trim(wildcard);
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_0
         return (check.StartsWith(wildcard), check.EndsWith(wildcard), trimmedCheck.Contains(wildcard)) switch {
 #else
         return (check.StartsWith(wildcard.ToString()), check.EndsWith(wildcard.ToString()), trimmedCheck.Contains(wildcard)) switch {
 #endif
             (var wildcardStart, var wildcardEnd, true) => MatchInnerWildcard(value, trimmedCheck.Split(wildcard), !wildcardStart, !wildcardEnd, comparison),
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_0
             (true, true, _) => value.Contains(trimmedCheck, comparison),
 #else
             (true, true, _) => value.IndexOf(trimmedCheck, comparison) >= 0,

--- a/src/ServiceRegistryModules.Core/ServiceCollectionExtensions.cs
+++ b/src/ServiceRegistryModules.Core/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ServiceCollectionExtensions {
     /// <exception cref="RegistryConfigurationException">When there is a problem with the registry configuration</exception>
     public static IServiceCollection ApplyRegistries(this IServiceCollection services, params Assembly[] assemblies)
         => services.ApplyRegistries(config => {
-            if (assemblies.Any()) {
+            if (assemblies.Length > 0) {
                 config.FromAssemblies(assemblies);
             }
         }, Assembly.GetCallingAssembly());
@@ -59,7 +59,7 @@ public static class ServiceCollectionExtensions {
     /// <exception cref="RegistryConfigurationException">When there is a problem with the registry configuration</exception>
     public static IServiceCollection ApplyRegistries(this IServiceCollection services, HostBuilderContext context, params Assembly[] assemblies)
         => services.ApplyRegistries(config => {
-            if (assemblies.Any()) {
+            if (assemblies.Length > 0) {
                 config.FromAssemblies(assemblies);
             }
             config.UsingConfiguration(context.Configuration);

--- a/src/ServiceRegistryModules.Core/ServiceCollectionRegistryConfiguration.cs
+++ b/src/ServiceRegistryModules.Core/ServiceCollectionRegistryConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_0
 using System.Diagnostics.CodeAnalysis;
 #endif
 using System.IO;
@@ -323,7 +323,7 @@ public class ServiceCollectionRegistryConfiguration {
                 var hintPath = addSection.GetSection(nameof(AddRegistryConfig.HintPath)).Value;
 
                 additionalRegistries.Add(new() {
-                    FullName = fullName,
+                    FullName = fullName!,
                     SuppressErrors = suppressErr,
                     HintPath = hintPath
                 });
@@ -342,7 +342,7 @@ public class ServiceCollectionRegistryConfiguration {
                     unresolvedTypes.Add(additionalReg.FullName);
                 }
             } else {
-                resolvedTypes.Add(additionalType);
+                resolvedTypes.Add(additionalType!);
             }
         }
 
@@ -369,20 +369,20 @@ public class ServiceCollectionRegistryConfiguration {
                 continue;
             }
 
-            var matchIdx = Options.RegistryTypes.FindIndex(t => skippedRegistry.Equals(t.FullName, StringComparison.OrdinalIgnoreCase));
+            var matchIdx = Options.RegistryTypes.FindIndex(t => skippedRegistry!.Equals(t.FullName, StringComparison.OrdinalIgnoreCase));
             if (matchIdx >= 0) {
                 Options.RegistryTypes.RemoveAt(matchIdx);
                 continue; // At this point we've already removed types that have an instance, so no need to continue
             }
 
-            matchIdx = Options.Registries.FindIndex(r => skippedRegistry.Equals(r.GetType().FullName, StringComparison.OrdinalIgnoreCase));
+            matchIdx = Options.Registries.FindIndex(r => skippedRegistry!.Equals(r.GetType().FullName, StringComparison.OrdinalIgnoreCase));
             if (matchIdx >= 0) {
                 Options.Registries.RemoveAt(matchIdx);
             }
         }
     }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_0
     private bool TryGetType(AddRegistryConfig addConfig, [NotNullWhen(true)] out Type? foundType) {
 #else
     private bool TryGetType(AddRegistryConfig addConfig, out Type? foundType) {
@@ -397,7 +397,7 @@ public class ServiceCollectionRegistryConfiguration {
             return false;
         }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if !NETSTANDARD2_0
         var typeName = fullTypeName[(lastIndex + 1)..];
         var assemblyName = fullTypeName[..lastIndex];
 #else

--- a/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
+++ b/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
+++ b/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
 
     <PackageId>ServiceRegistryModules</PackageId>
     <PackageVersion>1.1.1</PackageVersion>

--- a/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
+++ b/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>ServiceRegistryModules</PackageId>
-    <PackageVersion>1.1.1</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
     <Authors>Andrew Starr</Authors>
     <Description>
       Flexible modules for registering services with IServiceCollection

--- a/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
+++ b/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
 
     <PackageId>ServiceRegistryModules</PackageId>
     <PackageVersion>1.1.1</PackageVersion>

--- a/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
+++ b/src/ServiceRegistryModules.Core/ServiceRegistryModules.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net7.0;net8.0</TargetFrameworks>
 
     <PackageId>ServiceRegistryModules</PackageId>
     <PackageVersion>1.1.1</PackageVersion>

--- a/test/ServiceRegistryModules.AspNetCore.Tests/ServiceRegistryModules.AspNetCore.Tests.csproj
+++ b/test/ServiceRegistryModules.AspNetCore.Tests/ServiceRegistryModules.AspNetCore.Tests.csproj
@@ -6,15 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ServiceRegistryModules.AspNetCore.Tests/ServiceRegistryModules.AspNetCore.Tests.csproj
+++ b/test/ServiceRegistryModules.AspNetCore.Tests/ServiceRegistryModules.AspNetCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ServiceRegistryModules.AspNetCore.Tests/WebApplicationBuilderExtensions.Tests.cs
+++ b/test/ServiceRegistryModules.AspNetCore.Tests/WebApplicationBuilderExtensions.Tests.cs
@@ -194,7 +194,7 @@ public class WebApplicationBuilderExtensions_Should {
     #endregion
 
     #region Test Helpers
-    private WebApplicationBuilder CreateBuilder(Dependencies? deps = null) {
+    private static WebApplicationBuilder CreateBuilder(Dependencies? deps = null) {
         var builder = WebApplication.CreateBuilder();
         InternalServiceProvider.RegistryRunnerTestOverride = deps?.Runner.Object;
         return builder;

--- a/test/ServiceRegistryModules.AspNetCore.Tests/WebApplicationBuilderExtensions.Tests.cs
+++ b/test/ServiceRegistryModules.AspNetCore.Tests/WebApplicationBuilderExtensions.Tests.cs
@@ -195,13 +195,17 @@ public class WebApplicationBuilderExtensions_Should {
 
     #region Test Helpers
     private static WebApplicationBuilder CreateBuilder(Dependencies? deps = null) {
+#if NET8_0_OR_GREATER
+        var builder = WebApplication.CreateEmptyBuilder(new());
+#else
         var builder = WebApplication.CreateBuilder();
+#endif
         InternalServiceProvider.RegistryRunnerTestOverride = deps?.Runner.Object;
         return builder;
     }
 
     private static RegistryOptions CreateOptions() => new();
-    #endregion
+#endregion
 
     #region Test Classes
     private class TestRegistry1 : AbstractRegistryModule {

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
@@ -78,7 +78,7 @@ namespace ServiceRegistryModules.Internal.Tests {
             var handlerName = $"{typeof(Core.Internal.Tests.Utility).FullName}.{nameof(Core.Internal.Tests.Utility.OnMyPublicEvent)}";
             var configKey = $"{ServiceRegistryModulesDefaults.REGISTRIES_KEY}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}";
             var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(new Dictionary<string, string>() {
+                .AddInMemoryCollection(new Dictionary<string, string?>() {
                     { $"{configKey}:{nameof(TestSamples1.TestRegistry2)}:{nameof(TestSamples1.TestRegistry2.MyPublicEvent)}", handlerName }
                 });
 
@@ -117,7 +117,8 @@ namespace ServiceRegistryModules.Internal.Tests {
             using (new AssertionScope()) {
                 ex.Which.Message.Should().Be(formattedErrorMsg);
                 if (scenario.InnerExTypeName is not null) {
-                    ex.Which.InnerException.GetType().FullName.Should().Be(scenario.InnerExTypeName);
+                    ex.Which.InnerException.Should().NotBeNull();
+                    ex.Which.InnerException!.GetType().FullName.Should().Be(scenario.InnerExTypeName);
                 } else {
                     ex.Which.InnerException.Should().BeNull();
                 }

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
@@ -149,7 +149,7 @@ namespace ServiceRegistryModules.Internal.Tests {
         #endregion
 
         #region Test Data
-        private static IEnumerable<object[]> ExceptionData(string displayFormat) => new[] {
+        public static IEnumerable<object[]> ExceptionData(string displayFormat) => new[] {
             new object[] { new EventExceptionTestCase(displayFormat,
                 condition: "event handler assembly cannot be found",
                 handlerName: "Some.Bogus.Assembly.TestEventHandler",

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Event.Tests.cs
@@ -6,9 +6,9 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Win32;
 using ServiceRegistryModules.Exceptions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace ServiceRegistryModules.Internal.Tests {
     public partial class RegistryConfigApplicator_Should {
@@ -116,8 +116,8 @@ namespace ServiceRegistryModules.Internal.Tests {
             var ex = action.Should().Throw<RegistryConfigurationException>();
             using (new AssertionScope()) {
                 ex.Which.Message.Should().Be(formattedErrorMsg);
-                if (scenario.InnerExType is not null) {
-                    ex.Which.InnerException.Should().BeOfType(scenario.InnerExType);
+                if (scenario.InnerExTypeName is not null) {
+                    ex.Which.InnerException.GetType().FullName.Should().Be(scenario.InnerExTypeName);
                 } else {
                     ex.Which.InnerException.Should().BeNull();
                 }
@@ -149,60 +149,84 @@ namespace ServiceRegistryModules.Internal.Tests {
         #endregion
 
         #region Test Data
-        public static IEnumerable<object[]> ExceptionData(string displayFormat) => new[] {
-            new object[] { new EventExceptionTestCase(displayFormat,
+        public static TheoryData<EventExceptionTestCase> ExceptionData(string displayFormat) => new() {
+            new EventExceptionTestCase(displayFormat,
                 condition: "event handler assembly cannot be found",
                 handlerName: "Some.Bogus.Assembly.TestEventHandler",
                 expectedErrMsg: "'{0}' event handler could not be loaded from assembly 'Some.Bogus'.",
-                innerExType: typeof(FileNotFoundException)) },
+                innerExType: typeof(FileNotFoundException)),
 
-            new object[] { new EventExceptionTestCase(displayFormat,
+            new EventExceptionTestCase(displayFormat,
                 condition: "event handler declaring type cannot be found",
                 handlerName: $"{typeof(TestSamples2.TestRegistry1).FullName}_Oops.TestEventHandler",
                 expectedErrMsg: $"'{{0}}' event handler could not be found in type '{nameof(TestSamples2.TestRegistry1)}_Oops'.",
-                innerExType: typeof(TypeLoadException)) },
+                innerExType: typeof(TypeLoadException)),
 
-            new object[] { new EventExceptionTestCase(displayFormat,
+            new EventExceptionTestCase(displayFormat,
                 condition: "event handler method cannot be found",
                 handlerName: $"{typeof(TestSamples2.TestRegistry1).FullName}.TestEventHandler_Oops",
-                expectedErrMsg: $"'{{0}}' event handler could not be set from method 'TestEventHandler_Oops'. No such static method found.") },
+                expectedErrMsg: $"'{{0}}' event handler could not be set from method 'TestEventHandler_Oops'. No such static method found."),
 
-            new object[] { new EventExceptionTestCase(displayFormat,
+            new EventExceptionTestCase(displayFormat,
                 condition: "event handler method incompatible with delegate",
                 handlerName: $"{typeof(TestSamples2.TestRegistry1).FullName}.TestInvalidHandler",
                 expectedErrMsg: $"'{nameof(TestSamples2.TestRegistry1)}.TestInvalidHandler' is not a compatible event handler for '{{0}}'.",
-                innerExType: typeof(ArgumentException)) },
+                innerExType: typeof(ArgumentException)),
 
-            new object[] { new EventExceptionTestCase(displayFormat,
+            new EventExceptionTestCase(displayFormat,
                 condition: "configured handler does not include the assembly name",
                 handlerName: $"{nameof(TestSamples2.TestRegistry1)}.TestEventHandler",
-                expectedErrMsg: $"Invalid handler name ({nameof(TestSamples2.TestRegistry1)}.TestEventHandler). Please use the fully qualified handler name.") },
+                expectedErrMsg: $"Invalid handler name ({nameof(TestSamples2.TestRegistry1)}.TestEventHandler). Please use the fully qualified handler name."),
 
-            new object[] { new EventExceptionTestCase(displayFormat,
+            new EventExceptionTestCase(displayFormat,
                 condition: "configured handler does not include the type name",
                 handlerName: "TestEventHandler",
-                expectedErrMsg: "Invalid handler name (TestEventHandler). Please use the fully qualified handler name.") }
+                expectedErrMsg: "Invalid handler name (TestEventHandler). Please use the fully qualified handler name.")
         };
         #endregion
 
         #region Test Classes
-        public class EventExceptionTestCase {
-            private readonly string _displayFormat;
-            private readonly string _condition;
+        public class EventExceptionTestCase : IXunitSerializable {
+            public string DisplayFormat { get; private set; }
+            public string Condition { get; private set; }
+            public string HandlerName { get; private set; }
+            public string ExpectedErrMsg { get; private set; }
+            public string? InnerExTypeName { get; private set; }
+            public string? InnerExTypeShortName { get; private set; }
 
-            public string HandlerName { get; }
-            public string ExpectedErrMsg { get; }
-            public Type? InnerExType { get; }
-
-            public EventExceptionTestCase(string displayFormat, string condition, string handlerName, string expectedErrMsg, Type? innerExType = null) {
-                _displayFormat = displayFormat;
-                _condition = condition;
-                HandlerName = handlerName;
-                ExpectedErrMsg = expectedErrMsg;
-                InnerExType = innerExType;
+            public EventExceptionTestCase() {
+                DisplayFormat = string.Empty;
+                Condition = string.Empty;
+                HandlerName = string.Empty;
+                ExpectedErrMsg = string.Empty;
             }
 
-            public override string ToString() => string.Format(_displayFormat, _condition, InnerExType?.Name ?? nameof(RegistryConfigurationException)).Trim();
+            public EventExceptionTestCase(string displayFormat, string condition, string handlerName, string expectedErrMsg, Type? innerExType = null) {
+                DisplayFormat = displayFormat;
+                Condition = condition;
+                HandlerName = handlerName;
+                ExpectedErrMsg = expectedErrMsg;
+                InnerExTypeName = innerExType?.FullName;
+                InnerExTypeShortName = innerExType?.Name;
+            }
+
+            public override string ToString() => string.Format(DisplayFormat, Condition, InnerExTypeShortName ?? nameof(RegistryConfigurationException)).Trim();
+            public void Deserialize(IXunitSerializationInfo info) {
+                DisplayFormat = info.GetValue<string>(nameof(DisplayFormat));
+                Condition = info.GetValue<string>(nameof(Condition));
+                HandlerName = info.GetValue<string>(nameof(HandlerName));
+                ExpectedErrMsg = info.GetValue<string>(nameof(ExpectedErrMsg));
+                InnerExTypeName = info.GetValue<string?>(nameof(InnerExTypeName));
+                InnerExTypeShortName = info.GetValue<string?>(nameof(InnerExTypeShortName));
+            }
+            public void Serialize(IXunitSerializationInfo info) {
+                info.AddValue(nameof(DisplayFormat), DisplayFormat);
+                info.AddValue(nameof(Condition), Condition);
+                info.AddValue(nameof(HandlerName), HandlerName);
+                info.AddValue(nameof(ExpectedErrMsg), ExpectedErrMsg);
+                info.AddValue(nameof(InnerExTypeName), InnerExTypeName);
+                info.AddValue(nameof(InnerExTypeShortName), InnerExTypeShortName);
+            }
         }
         #endregion
     }

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
@@ -96,9 +96,9 @@ namespace ServiceRegistryModules.Internal.Tests {
         #region Test Inputs
         public static TheoryData<int, string[]> KeyMatchingInputs()
             => new() {
-                { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
-                { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace2.TestRegistry).FullName } },
-                { 1, new[] { typeof(Namespace2.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
+                { 0, new[] { typeof(Namespace1.TestRegistry).FullName!, typeof(Namespace1.TestRegistry).Name } },
+                { 0, new[] { typeof(Namespace1.TestRegistry).FullName!, typeof(Namespace2.TestRegistry).FullName! } },
+                { 1, new[] { typeof(Namespace2.TestRegistry).FullName!, typeof(Namespace1.TestRegistry).Name } },
                 { 1, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", typeof(Namespace1.TestRegistry).Name } },
                 { 0, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", "ServiceRegistryModules.Internal.Tests.*" } },
                 { 0, new[] { "ServiceRegistryModules.Internal.Test*", "ServiceRegistryModules.Internal*Test*" } },

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
@@ -94,15 +94,15 @@ namespace ServiceRegistryModules.Internal.Tests {
         #endregion
 
         #region Test Inputs
-        public static IEnumerable<object[]> KeyMatchingInputs()
-            => new[] {
-                new object[] { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
-                new object[] { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace2.TestRegistry).FullName } },
-                new object[] { 1, new[] { typeof(Namespace2.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
-                new object[] { 1, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", typeof(Namespace1.TestRegistry).Name } },
-                new object[] { 0, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", "ServiceRegistryModules.Internal.Tests.*" } },
-                new object[] { 0, new[] { "ServiceRegistryModules.Internal.Test*", "ServiceRegistryModules.Internal*Test*" } },
-                new object[] { 1, new[] { "*ServiceRegistryModules.Internal.Test*", "ServiceRegistryModules.Internal.Test*" } }
+        public static TheoryData<int, string[]> KeyMatchingInputs()
+            => new() {
+                { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
+                { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace2.TestRegistry).FullName } },
+                { 1, new[] { typeof(Namespace2.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
+                { 1, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", typeof(Namespace1.TestRegistry).Name } },
+                { 0, new[] { "ServiceRegistryModules.Internal.Tests.*.TestRegistry", "ServiceRegistryModules.Internal.Tests.*" } },
+                { 0, new[] { "ServiceRegistryModules.Internal.Test*", "ServiceRegistryModules.Internal*Test*" } },
+                { 1, new[] { "*ServiceRegistryModules.Internal.Test*", "ServiceRegistryModules.Internal.Test*" } }
             };
         #endregion
 

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigApplicator.Tests.cs
@@ -94,7 +94,7 @@ namespace ServiceRegistryModules.Internal.Tests {
         #endregion
 
         #region Test Inputs
-        private static IEnumerable<object[]> KeyMatchingInputs()
+        public static IEnumerable<object[]> KeyMatchingInputs()
             => new[] {
                 new object[] { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace1.TestRegistry).Name } },
                 new object[] { 0, new[] { typeof(Namespace1.TestRegistry).FullName, typeof(Namespace2.TestRegistry).FullName } },

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigLoader.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryConfigLoader.Tests.cs
@@ -161,7 +161,7 @@ public class RegistryConfigLoader_Should {
         var expectedValue = "some-value-in-another-key";
         var otherKey = "some:other:key";
 
-        var configEntries = new Dictionary<string, string> {
+        var configEntries = new Dictionary<string, string?> {
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:value", otherKey },
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:type", ConfigurationType.Config.ToString().ToLower() },
             { otherKey, expectedValue }
@@ -186,7 +186,7 @@ public class RegistryConfigLoader_Should {
         var key = "my_registry_config";
         var otherKey = "some:missing:key";
 
-        var configEntries = new Dictionary<string, string> {
+        var configEntries = new Dictionary<string, string?> {
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:value", otherKey },
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:type", ConfigurationType.Config.ToString().ToLower() },
             { otherKey.Replace(":missing:", ":not_missing:"), "some-value" }
@@ -209,7 +209,7 @@ public class RegistryConfigLoader_Should {
         var key = "my_registry_config";
         var otherKey = "some:missing:key";
 
-        var configEntries = new Dictionary<string, string> {
+        var configEntries = new Dictionary<string, string?> {
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:value", otherKey },
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:type", ConfigurationType.Config.ToString().ToLower() },
             { $"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:registry1:prop1:suppresserrors", "true" },
@@ -264,7 +264,7 @@ public class RegistryConfigLoader_Should {
         var key = "registry_config";
 
         var options = CreateOptions(builder => builder.AddInMemoryCollection(new[] {
-            KeyValuePair.Create($"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:SomeRegistry", "no-properties")
+            KeyValuePair.Create($"{key}:{ServiceRegistryModulesDefaults.CONFIGURATION_KEY}:SomeRegistry", (string?)"no-properties")
         }), sectionKey: key);
         var service = CreateService();
 

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryRunner.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryRunner.Tests.cs
@@ -113,8 +113,9 @@ public class RegistryRunner_Should {
         MemberData(nameof(EnvironmentMatchInput), "production"),
         MemberData(nameof(EnvironmentMatchInput), null),
         MemberData(nameof(EnvironmentMatchInput), "staging")]
-    public void NotApplyConfigurations_OrConfigureServices_ForRegistriesThatDoNotMatchTheCurrentEnvironment(Mock<IRegistryModule>[] registries, string? environment, int[] expectedIndicies) {
+    public void NotApplyConfigurations_OrConfigureServices_ForRegistriesThatDoNotMatchTheCurrentEnvironment(string[][] registryEnvironments, string? environment, int[] expectedIndicies) {
         // Arrange
+        var registries = registryEnvironments.Select(env => CreateMockRegistry(env)).ToArray();
         var hostEnv = environment == null ? null : new TestEnvironment(environment);
         var options = CreateOptions(environment: hostEnv);
         var mock = new Dependencies();
@@ -152,32 +153,32 @@ public class RegistryRunner_Should {
     #endregion
 
     #region Test Inputs
-    public static IEnumerable<object[]> EnvironmentMatchInput(string? actualEnvironment) {
-        var registries = new[] {
-            CreateMockRegistry("Development"),
-            CreateMockRegistry("production"),
-            CreateMockRegistry("development", "Production"),
-            CreateMockRegistry()
+    public static TheoryData<string[][], string, int[]> EnvironmentMatchInput(string? actualEnvironment) {
+        var registryEnvironments = new string[][] {
+            new[] { "Development" },
+            new[] { "production" },
+            new[] { "development", "Production" },
+            Array.Empty<string>()
         };
         var expectedRegistryIndicies = new List<int>();
 
-        for (var i = 0; i < registries.Length; i++) {
+        for (var i = 0; i < registryEnvironments.Length; i++) {
             if (actualEnvironment is null) {
                 expectedRegistryIndicies.Add(i);
                 continue;
             }
-            if (registries[i].Object.TargetEnvironments.Contains(actualEnvironment, StringComparer.OrdinalIgnoreCase)) {
+            if (registryEnvironments[i].Contains(actualEnvironment, StringComparer.OrdinalIgnoreCase)) {
                 expectedRegistryIndicies.Add(i);
                 continue;
             }
-            if (registries[i].Object.TargetEnvironments.Count == 0) {
+            if (registryEnvironments[i].Length == 0) {
                 expectedRegistryIndicies.Add(i);
             }
         }
 
-        return new object[][] {
-            new object[] {
-                registries,
+        return new() {
+            { 
+                registryEnvironments,
                 actualEnvironment!,
                 expectedRegistryIndicies.ToArray()
             }

--- a/test/ServiceRegistryModules.Core.Internal.Tests/RegistryRunner.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/RegistryRunner.Tests.cs
@@ -152,7 +152,7 @@ public class RegistryRunner_Should {
     #endregion
 
     #region Test Inputs
-    private static IEnumerable<object[]> EnvironmentMatchInput(string? actualEnvironment) {
+    public static IEnumerable<object[]> EnvironmentMatchInput(string? actualEnvironment) {
         var registries = new[] {
             CreateMockRegistry("Development"),
             CreateMockRegistry("production"),

--- a/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
@@ -8,17 +8,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
+++ b/test/ServiceRegistryModules.Core.Internal.Tests/ServiceRegistryModules.Core.Internal.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/test/ServiceRegistryModules.Core.Tests/ServiceCollectionExtensions.Tests.cs
+++ b/test/ServiceRegistryModules.Core.Tests/ServiceCollectionExtensions.Tests.cs
@@ -322,7 +322,7 @@ public class ServiceCollectionExtensions_Should {
         var key = "my_configured_key";
         var configKey = $"{key}:{ServiceRegistryModulesDefaults.ADD_MODULES_KEY}";
         var configBuilder = new ConfigurationBuilder();
-        configBuilder.AddInMemoryCollection(new Dictionary<string, string> {
+        configBuilder.AddInMemoryCollection(new Dictionary<string, string?> {
             { $"{configKey}:0:fullname", "UnreferencedTestSamples.TestRegistry1" },
             { $"{configKey}:0:hintpath", "../../../../SampleProjects/UnreferencedTestSamples/bin/Debug/netstandard2.1/UnreferencedTestSamples.dll" },
             { $"{configKey}:1", regType.FullName! }
@@ -353,7 +353,7 @@ public class ServiceCollectionExtensions_Should {
 
         var configKey = $"{ServiceRegistryModulesDefaults.REGISTRIES_KEY}:{ServiceRegistryModulesDefaults.ADD_MODULES_KEY}";
         var configBuilder = new ConfigurationBuilder();
-        configBuilder.AddInMemoryCollection(configuredAdditions.SelectMany((name, i) => new[] { KeyValuePair.Create($"{configKey}:{i}", name) }));
+        configBuilder.AddInMemoryCollection(configuredAdditions.SelectMany((name, i) => new[] { KeyValuePair.Create($"{configKey}:{i}", (string?)name) }));
 
         // Act
         var action = () => services.ApplyRegistries(config => config.UsingConfiguration(configBuilder.Build()));
@@ -380,10 +380,10 @@ public class ServiceCollectionExtensions_Should {
         var configKey = $"{ServiceRegistryModulesDefaults.REGISTRIES_KEY}:{ServiceRegistryModulesDefaults.ADD_MODULES_KEY}";
         var configBuilder = new ConfigurationBuilder();
         configBuilder.AddInMemoryCollection(configuredAdditions.SelectMany((name, i) => name == validRegistryName
-                ? (new[] { KeyValuePair.Create($"{configKey}:{i}", name) })
-                : (IEnumerable<KeyValuePair<string, string>>)(new[] {
-                    KeyValuePair.Create($"{configKey}:{i}:FullName", name),
-                    KeyValuePair.Create($"{configKey}:{i}:SuppressErrors", "true")
+                ? (new[] { KeyValuePair.Create($"{configKey}:{i}", (string?)name) })
+                : (IEnumerable<KeyValuePair<string, string?>>)(new[] {
+                    KeyValuePair.Create($"{configKey}:{i}:FullName", (string?)name),
+                    KeyValuePair.Create($"{configKey}:{i}:SuppressErrors", (string?)"true")
                 })));
 
         // Act

--- a/test/ServiceRegistryModules.Core.Tests/ServiceRegistryModules.Core.Tests.csproj
+++ b/test/ServiceRegistryModules.Core.Tests/ServiceRegistryModules.Core.Tests.csproj
@@ -8,16 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/ServiceRegistryModules.Core.Tests/ServiceRegistryModules.Core.Tests.csproj
+++ b/test/ServiceRegistryModules.Core.Tests/ServiceRegistryModules.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
In order to take advantage of performance improvements in .NET 6-8 runtimes, I've added TFMs for those in all projects in addition to the netstandard ones that were already there.

Also cleaned up warnings and made small tweaks for performance based on the new TFM APIs.